### PR TITLE
Not found redhat7.4 build_boot_image

### DIFF
--- a/kubam/app/autoinstall/builder.py
+++ b/kubam/app/autoinstall/builder.py
@@ -98,7 +98,7 @@ class Builder(object):
 
     @staticmethod
     def build_boot_image(node, template, net_template):
-        if node['os'] in ["centos7.3", "centos7.4", "redhat7.2", "rhvh4.1", "redhat7.5", "centos7.5"]:
+        if node['os'] in ["centos7.3", "centos7.4", "redhat7.2", "redhat7.4", "rhvh4.1", "redhat7.5", "centos7.5"]:
             return Kickstart.build_boot_image(node, template)
         if node['os'] in ["esxi6.0", "esxi6.5"]:
             return VMware.build_boot_image(node, template)


### PR DESCRIPTION
When try  deploy image with /api/v2/deploy/images  Not found redhat7.4 , the erros is : 
`no os is built! for os %s and node redhat7.4"`
in builder.py build_boot_image and this not generate Kickstart